### PR TITLE
ci: add feature request issue templates

### DIFF
--- a/.gitea/issue_template/feature_request.yaml
+++ b/.gitea/issue_template/feature_request.yaml
@@ -1,0 +1,36 @@
+name: Feature Request
+about: Suggest a new feature or enhancement.
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Searched existing issues
+      description: Search existing issues to avoid duplicates.
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+
+  - type: checkboxes
+    attributes:
+      label: Willing to contribute
+      options:
+        - label: I am willing to submit a pull request for this.
+          required: false
+
+  - type: textarea
+    attributes:
+      label: Problem
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest a new feature or enhancement.
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: searched
+    attributes:
+      label: Searched existing issues
+      description: Search existing issues to avoid duplicates.
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Willing to contribute
+      options:
+        - label: I am willing to submit a pull request for this.
+          required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false


### PR DESCRIPTION
## Problem

No structured feature request template for GitHub or Codeberg, leading to inconsistent enhancement proposals.

## Solution

Add feature request templates with separate checkbox blocks for duplicate search and willingness to contribute.