### PR TITLE
Update translations for Spanish and tweak string wording

### DIFF
--- a/src/Lektra.cpp
+++ b/src/Lektra.cpp
@@ -4254,7 +4254,7 @@ Lektra::initCommands() noexcept
         [this](const QStringList &) { Show_annot_comment_search(); });
 
     // Search
-    m_command_manager->reg("search", "Search document",
+    m_command_manager->reg("search", tr("Search document"),
                            [this](const QStringList &args) { Search(args); });
     m_command_manager->reg("search_regex", tr("Search document using regex"),
                            [this](const QStringList &args)

--- a/src/SearchBar.cpp
+++ b/src/SearchBar.cpp
@@ -13,7 +13,7 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
 
     // Set color based on the current palette's text color
     m_spinner->setColor(palette().color(QPalette::Text));
-    m_label            = new QLabel("Search:", this);
+    m_label            = new QLabel(tr("Search:"), this);
     m_searchInput      = new QLineEdit(this);
     m_prevButton       = new QPushButton(this);
     m_nextButton       = new QPushButton(this);
@@ -23,14 +23,14 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
 
     m_searchInput->setFocusPolicy(Qt::ClickFocus);
 
-    m_regexButton->setToolTip("Regular Expression");
+    m_regexButton->setToolTip(tr("Regular Expression"));
     m_regexButton->setCheckable(true);
     m_regexButton->setFixedWidth(28);
     m_regexButton->setFocusPolicy(Qt::NoFocus);
 
-    m_nextButton->setToolTip("Goto Next Hit");
-    m_prevButton->setToolTip("Goto Previous Hit");
-    m_closeButton->setToolTip("Close Search Bar");
+    m_nextButton->setToolTip(tr("Goto Next Hit"));
+    m_prevButton->setToolTip(tr("Goto Previous Hit"));
+    m_closeButton->setToolTip(tr("Close Search Bar"));
 
     m_nextButton->setIcon(style()->standardIcon(QStyle::SP_ArrowForward));
     m_prevButton->setIcon(style()->standardIcon(QStyle::SP_ArrowBack));
@@ -52,7 +52,7 @@ SearchBar::SearchBar(QWidget *parent) : QWidget(parent)
                                       QSizePolicy::Preferred);
     m_searchInput->setSizePolicy(QSizePolicy::Expanding,
                                  QSizePolicy::Preferred);
-    m_searchInput->setPlaceholderText("Search");
+    m_searchInput->setPlaceholderText(tr("Search query…"));
     m_searchIndexLabel->hide();
     m_searchSeparator->hide();
     m_searchCountLabel->hide();
@@ -79,8 +79,8 @@ SearchBar::initConnections() noexcept
             emit searchIndexChangeRequested(index - 1);
         else
         {
-            QMessageBox::warning(this, "Invalid Index",
-                                 "Please enter a valid search index.");
+            QMessageBox::warning(this, tr("Invalid Index"),
+                                 tr("Please enter a valid search index."));
         }
     });
 

--- a/src/Translations/lektra.es.ts
+++ b/src/Translations/lektra.es.ts
@@ -33,12 +33,12 @@
 <context>
     <name>DocumentView</name>
     <message>
-        <location filename="../DocumentView.cpp" line="532"/>
+        <location filename="../DocumentView.cpp" line="605"/>
         <source>Search</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="533"/>
+        <location filename="../DocumentView.cpp" line="606"/>
         <source>No matches found for the given term.</source>
         <translation>No se encontraron coincidencias para este término.</translation>
     </message>
@@ -51,62 +51,72 @@
         <translation type="vanished">Editar anotación:</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3453"/>
+        <location filename="../DocumentView.cpp" line="307"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="308"/>
+        <source>Failed to open the file. Please check if the file exists and is a supported format.</source>
+        <translation>No se pudo abrir el archivo. Por favor, verifica si el archivo existe y es un formato soportado.</translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="3724"/>
         <source>Add Comment</source>
         <translation>Añadir comentario</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3453"/>
+        <location filename="../DocumentView.cpp" line="3724"/>
         <source>Enter annotation comment:</source>
         <translation>Escribir comentario de la anotación:</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3996"/>
+        <location filename="../DocumentView.cpp" line="4281"/>
         <source>Save Image</source>
         <translation>Guardar imagen</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3997"/>
+        <location filename="../DocumentView.cpp" line="4282"/>
         <source>PNG Image</source>
         <translation>imagen PNG</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3998"/>
+        <location filename="../DocumentView.cpp" line="4282"/>
         <source>JPEG Image</source>
         <translation>imagen JPG</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3999"/>
+        <location filename="../DocumentView.cpp" line="4283"/>
         <source>BMP Image</source>
         <translation>imagen BMP</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4222"/>
+        <location filename="../DocumentView.cpp" line="4505"/>
         <source>Add Note</source>
         <translation>Añadir nota</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4222"/>
+        <location filename="../DocumentView.cpp" line="4505"/>
         <source>Enter annotation text:</source>
         <translation>Texto de la anotación:</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4456"/>
+        <location filename="../DocumentView.cpp" line="4721"/>
         <source>Password Required</source>
         <translation>Se requiere contraseña</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4456"/>
+        <location filename="../DocumentView.cpp" line="4721"/>
         <source>Enter password:</source>
         <translation>Escribe la contraseña:</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4475"/>
+        <location filename="../DocumentView.cpp" line="4740"/>
         <source>Incorrect Password</source>
         <translation>Contraseña incorrecta</translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4476"/>
+        <location filename="../DocumentView.cpp" line="4741"/>
         <source>The password you entered is incorrect.</source>
         <translation>La contraseña que escribiste no es correcta.</translation>
     </message>
@@ -170,17 +180,17 @@
 <context>
     <name>HighlightAnnotation</name>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="105"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="97"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="106"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="98"/>
         <source>Change Color</source>
         <translation>Cambiar color</translation>
     </message>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="107"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="99"/>
         <source>Comment</source>
         <translation>Comentar</translation>
     </message>
@@ -188,358 +198,358 @@
 <context>
     <name>Lektra</name>
     <message>
-        <location filename="../Lektra.cpp" line="118"/>
+        <location filename="../Lektra.cpp" line="139"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="121"/>
+        <location filename="../Lektra.cpp" line="142"/>
         <source>Open File	%1</source>
         <translation>Abrir archivo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="124"/>
+        <location filename="../Lektra.cpp" line="145"/>
         <source>Open File In VSplit	%1</source>
         <translation>Abrir archivo en vista dividida vertical	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="128"/>
+        <location filename="../Lektra.cpp" line="149"/>
         <source>Open File In HSplit	%1</source>
         <translation>Abrir archivo en vista dividida horizontal	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="132"/>
-        <location filename="../Lektra.cpp" line="4963"/>
+        <location filename="../Lektra.cpp" line="153"/>
+        <location filename="../Lektra.cpp" line="5535"/>
         <source>Recent Files</source>
         <translation>Archivos recientes</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="135"/>
+        <location filename="../Lektra.cpp" line="156"/>
         <source>File Properties	%1</source>
         <translation>Propiedades del archivo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="140"/>
+        <location filename="../Lektra.cpp" line="160"/>
         <source>Open Containing Folder	%1</source>
         <translation>Abrir carpeta contenedora	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="146"/>
+        <location filename="../Lektra.cpp" line="166"/>
         <source>Save File	%1</source>
         <translation>Guardar archivo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="150"/>
+        <location filename="../Lektra.cpp" line="170"/>
         <source>Save As File	%1</source>
         <translation>Guardar como archivo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="153"/>
+        <location filename="../Lektra.cpp" line="173"/>
         <source>Session</source>
         <translation>Sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="156"/>
+        <location filename="../Lektra.cpp" line="176"/>
         <source>Save	%1</source>
         <translation>Guardar	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="159"/>
+        <location filename="../Lektra.cpp" line="179"/>
         <source>Save As	%1</source>
         <translation>Guardar como	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="162"/>
+        <location filename="../Lektra.cpp" line="182"/>
         <source>Load	%1</source>
         <translation>Cargar	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="168"/>
+        <location filename="../Lektra.cpp" line="188"/>
         <source>Close File	%1</source>
         <translation>Cerrar archivo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="172"/>
+        <location filename="../Lektra.cpp" line="192"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="174"/>
+        <location filename="../Lektra.cpp" line="194"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="176"/>
+        <location filename="../Lektra.cpp" line="196"/>
         <source>Undo	%1</source>
         <translation>Deshacer	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="179"/>
+        <location filename="../Lektra.cpp" line="198"/>
         <source>Redo	%1</source>
         <translation>Rehacer	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="184"/>
+        <location filename="../Lektra.cpp" line="202"/>
         <source>Last Pages	%1</source>
         <translation>Últimas páginas	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="188"/>
+        <location filename="../Lektra.cpp" line="206"/>
         <source>&amp;View</source>
         <translation>&amp;Vista</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="190"/>
+        <location filename="../Lektra.cpp" line="208"/>
         <source>Fullscreen	%1</source>
         <translation>Pantalla completa	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="196"/>
+        <location filename="../Lektra.cpp" line="214"/>
         <source>Zoom In	%1</source>
         <translation>Acercar	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="199"/>
+        <location filename="../Lektra.cpp" line="217"/>
         <source>Zoom Out	%1</source>
         <translation>Alejar	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="204"/>
+        <location filename="../Lektra.cpp" line="222"/>
         <source>Fit</source>
         <translation>Ajustar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="207"/>
+        <location filename="../Lektra.cpp" line="225"/>
         <source>Width	%1</source>
         <translation>Al ancho	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="211"/>
+        <location filename="../Lektra.cpp" line="229"/>
         <source>Height	%1</source>
         <translation>Al largo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="215"/>
+        <location filename="../Lektra.cpp" line="233"/>
         <source>Page	%1</source>
         <translation>A la página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="222"/>
+        <location filename="../Lektra.cpp" line="240"/>
         <source>Auto Fit	%1</source>
         <translation>Ajuste automático	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="231"/>
+        <location filename="../Lektra.cpp" line="249"/>
         <source>Layout</source>
         <translation>Disposición</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="236"/>
+        <location filename="../Lektra.cpp" line="254"/>
         <source>Single Page	%1</source>
         <translation>Una sola página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="240"/>
+        <location filename="../Lektra.cpp" line="258"/>
         <source>Left to Right Page	%1</source>
         <translation>Página de izquierda a derecha	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="245"/>
+        <location filename="../Lektra.cpp" line="263"/>
         <source>Top to Bottom Page	%1</source>
         <translation>Página de arriba a abajo	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="250"/>
+        <location filename="../Lektra.cpp" line="267"/>
         <source>Book	%1</source>
         <translation>Libro	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="275"/>
+        <location filename="../Lektra.cpp" line="292"/>
         <source>Show/Hide</source>
         <translation>Mostrar u ocultar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="279"/>
+        <location filename="../Lektra.cpp" line="296"/>
         <source>LLM Widget	%1</source>
         <translation>Widget LLM	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="286"/>
+        <location filename="../Lektra.cpp" line="303"/>
         <source>Command Picker	%1</source>
         <translation>Selector de comandos	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="290"/>
+        <location filename="../Lektra.cpp" line="307"/>
         <source>Outline	%1</source>
         <translation>Bordes	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="297"/>
+        <location filename="../Lektra.cpp" line="311"/>
         <source>Highlight Annotation Search	%1</source>
         <translation>Resaltar búsqueda de anotación	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="305"/>
+        <location filename="../Lektra.cpp" line="316"/>
         <source>Menubar	%1</source>
         <translation>Barra de menú	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="311"/>
+        <location filename="../Lektra.cpp" line="322"/>
         <source>Tabs	%1</source>
         <translation>Pestañas	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="317"/>
+        <location filename="../Lektra.cpp" line="328"/>
         <source>Statusbar	%1</source>
         <translation>Barra de estado	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="323"/>
+        <location filename="../Lektra.cpp" line="334"/>
         <source>Invert Color	%1</source>
         <translation>Invertir colores	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="330"/>
+        <location filename="../Lektra.cpp" line="341"/>
         <source>Tools</source>
         <translation>Herramientas</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="332"/>
+        <location filename="../Lektra.cpp" line="343"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="338"/>
+        <location filename="../Lektra.cpp" line="349"/>
         <source>Region Selection	%1</source>
         <translation>Selección de región	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="345"/>
+        <location filename="../Lektra.cpp" line="356"/>
         <source>Text Selection	%1</source>
         <translation>Selección de texto	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="352"/>
+        <location filename="../Lektra.cpp" line="362"/>
         <source>Text Highlight	%1</source>
         <translation>Resaltado de texto	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="359"/>
+        <location filename="../Lektra.cpp" line="368"/>
         <source>Annotate Rectangle	%1</source>
         <translation>Anotación rectangular	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="366"/>
+        <location filename="../Lektra.cpp" line="374"/>
         <source>Edit Annotations	%1</source>
         <translation>Editar anotaciones	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="373"/>
+        <location filename="../Lektra.cpp" line="380"/>
         <source>Annotate Popup	%1</source>
         <translation>Diálogo de anotación	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="381"/>
+        <location filename="../Lektra.cpp" line="387"/>
         <source>Visual Line Mode	%1</source>
         <translation>Modo de línea visual	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="388"/>
+        <location filename="../Lektra.cpp" line="393"/>
         <source>None	%1</source>
         <translation>Ninguna	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="427"/>
+        <location filename="../Lektra.cpp" line="432"/>
         <source>Encrypt Document	%1</source>
         <translation>Encriptar documento	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="432"/>
+        <location filename="../Lektra.cpp" line="437"/>
         <source>Decrypt Document	%1</source>
         <translation>Desencriptar documento	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="437"/>
+        <location filename="../Lektra.cpp" line="442"/>
         <source>&amp;Navigation</source>
         <translation>&amp;Navegación</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="440"/>
+        <location filename="../Lektra.cpp" line="445"/>
         <source>StartPage	%1</source>
         <translation>Página de inicio	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="444"/>
+        <location filename="../Lektra.cpp" line="449"/>
         <source>Goto Page	%1</source>
         <translation>Ir a la página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="448"/>
+        <location filename="../Lektra.cpp" line="453"/>
         <source>First Page	%1</source>
         <translation>Primera página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="452"/>
+        <location filename="../Lektra.cpp" line="457"/>
         <source>Previous Page	%1</source>
         <translation>Página anterior	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="456"/>
+        <location filename="../Lektra.cpp" line="461"/>
         <source>Next Page	%1</source>
         <translation>Siguiente página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="459"/>
+        <location filename="../Lektra.cpp" line="464"/>
         <source>Last Page	%1</source>
         <translation>Última página	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="463"/>
+        <location filename="../Lektra.cpp" line="468"/>
         <source>Previous Location	%1</source>
         <translation>Ubicación anterior	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="467"/>
+        <location filename="../Lektra.cpp" line="471"/>
         <source>Next Location	%1</source>
         <translation>Siguiente ubicación	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="470"/>
+        <location filename="../Lektra.cpp" line="474"/>
         <source>Marks</source>
         <translation>Marcadores</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="473"/>
+        <location filename="../Lektra.cpp" line="477"/>
         <source>Set Mark	%1</source>
         <translation>Añadir marcador	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="477"/>
+        <location filename="../Lektra.cpp" line="481"/>
         <source>Goto Mark	%1</source>
         <translation>Ir a marcador	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="481"/>
+        <location filename="../Lektra.cpp" line="485"/>
         <source>Delete Mark	%1</source>
         <translation>Eliminar marcador	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="485"/>
+        <location filename="../Lektra.cpp" line="489"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="487"/>
+        <location filename="../Lektra.cpp" line="491"/>
         <source>About	%1</source>
         <translation>Acerca de	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="491"/>
+        <location filename="../Lektra.cpp" line="495"/>
         <source>Open Tutorial File	%1</source>
         <translation>Abrir archivo de tutorial	%1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="535"/>
+        <location filename="../Lektra.cpp" line="539"/>
         <source>There are one or more error(s) in your config file:
 %1
 
@@ -550,49 +560,43 @@ Loading default config.</source>
 Cargando configuración predeterminada.</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1121"/>
+        <location filename="../Lektra.cpp" line="1214"/>
         <source>%1 -&gt; %2</source>
         <translation>%1 -&gt; %2</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1131"/>
+        <location filename="../Lektra.cpp" line="1224"/>
         <source>Shortcut conflict(s): %1</source>
         <translation>Conflicto(s) entre atajo(s): %1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1135"/>
+        <location filename="../Lektra.cpp" line="1228"/>
         <source>Shortcut conflict(s): %1; and %2 more</source>
         <translation>Conflicto(s) entre atajo(s): %1; y %2 más</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1178"/>
+        <location filename="../Lektra.cpp" line="1273"/>
         <source>LLM: Unknown action</source>
         <translation>LLM: acción desconocida</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1623"/>
+        <location filename="../Lektra.cpp" line="1902"/>
         <source>Enter page number (1 to %1)</source>
         <translation>Número de página (de 1 a %1)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1632"/>
+        <location filename="../Lektra.cpp" line="1917"/>
         <source>Page %1 is out of range</source>
         <translation>La página %1 está fuera del rango</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1822"/>
-        <location filename="../Lektra.cpp" line="1993"/>
-        <location filename="../Lektra.cpp" line="2111"/>
-        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="2502"/>
         <source>PDF Files</source>
         <translation>Archivos PDF</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1822"/>
-        <location filename="../Lektra.cpp" line="1993"/>
-        <location filename="../Lektra.cpp" line="2111"/>
-        <location filename="../Lektra.cpp" line="2202"/>
-        <location filename="../Lektra.cpp" line="3482"/>
+        <location filename="../Lektra.cpp" line="2503"/>
+        <location filename="../Lektra.cpp" line="3881"/>
         <source>All Files</source>
         <translation>Todos los archivos</translation>
     </message>
@@ -601,849 +605,907 @@ Cargando configuración predeterminada.</translation>
         <translation type="obsolete">Archivos PDF (*.pdf);;Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1837"/>
-        <location filename="../Lektra.cpp" line="2008"/>
-        <location filename="../Lektra.cpp" line="4695"/>
+        <location filename="../Lektra.cpp" line="2136"/>
+        <location filename="../Lektra.cpp" line="2292"/>
+        <location filename="../Lektra.cpp" line="5179"/>
+        <location filename="../Lektra.cpp" line="5798"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1838"/>
-        <location filename="../Lektra.cpp" line="2009"/>
-        <location filename="../Lektra.cpp" line="4696"/>
+        <location filename="../Lektra.cpp" line="2137"/>
+        <location filename="../Lektra.cpp" line="2293"/>
+        <location filename="../Lektra.cpp" line="5180"/>
         <source>The specified file does not exist:
 %1</source>
         <translation>El archivo no existe:
 %1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="2501"/>
         <source>Open File</source>
         <translation>Abrir archivo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2239"/>
+        <location filename="../Lektra.cpp" line="2541"/>
         <source>Unable to find %1</source>
         <translation>No se encontró el archivo %1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2784"/>
+        <location filename="../Lektra.cpp" line="3157"/>
         <source>File %1 has unsaved changes. Do you want to save them?</source>
         <translation>El archivo %1 tiene cambios sin guardar. ¿Deseas guardarlos?</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2807"/>
+        <location filename="../Lektra.cpp" line="3180"/>
         <source>Confirm Quit</source>
         <translation>Confirmar cierre</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2807"/>
+        <location filename="../Lektra.cpp" line="3181"/>
         <source>Are you sure you want to quit Lektra?</source>
         <translation>¿Estás seguro de que quieres salir de Lektra?</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2924"/>
+        <location filename="../Lektra.cpp" line="3345"/>
         <source>Open Location</source>
         <translation>Abrir ruta</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2926"/>
+        <location filename="../Lektra.cpp" line="3347"/>
         <source>File Properties</source>
         <translation>Propiedades del archivo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2929"/>
+        <location filename="../Lektra.cpp" line="3350"/>
         <source>Move Tab to New Window</source>
         <translation>Mover pestaña a una ventana nueva</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2936"/>
+        <location filename="../Lektra.cpp" line="3357"/>
         <source>Close Tab</source>
         <translation>Cerrar pestaña</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3287"/>
-        <location filename="../Lektra.cpp" line="3295"/>
+        <location filename="../Lektra.cpp" line="3686"/>
+        <location filename="../Lektra.cpp" line="3695"/>
         <source>Load Session</source>
         <translation>Cargar sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3287"/>
+        <location filename="../Lektra.cpp" line="3687"/>
         <source>No sessions found</source>
         <translation>No se encontraron sesiones</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3296"/>
+        <location filename="../Lektra.cpp" line="3696"/>
         <source>Session to load (existing sessions are listed): </source>
         <translation>Sesión a cargar (se muestran las sesiones existentes): </translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3309"/>
-        <location filename="../Lektra.cpp" line="3319"/>
+        <location filename="../Lektra.cpp" line="3709"/>
+        <location filename="../Lektra.cpp" line="3719"/>
         <source>Session File Parse Error</source>
         <translation>Error al procesar el archivo de sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3312"/>
+        <location filename="../Lektra.cpp" line="3712"/>
         <source>JSON parse error:</source>
         <translation>Error de análisis de JSON:</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3320"/>
-        <location filename="../Lektra.cpp" line="3322"/>
+        <location filename="../Lektra.cpp" line="3720"/>
+        <location filename="../Lektra.cpp" line="3722"/>
         <source>Session file root is not an array</source>
         <translation>El archivo raíz de la sesión no es un arreglo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3344"/>
+        <location filename="../Lektra.cpp" line="3744"/>
         <source>Open Session</source>
         <translation>Abrir sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3345"/>
+        <location filename="../Lektra.cpp" line="3745"/>
         <source>Could not open session: %1</source>
         <translation>No se pudo abrir la sesión %1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3360"/>
+        <location filename="../Lektra.cpp" line="3759"/>
         <source>Session Directory</source>
         <translation>Directorio de sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3361"/>
+        <location filename="../Lektra.cpp" line="3760"/>
         <source>Unable to create sessions directory due to an unknown error.</source>
         <translation>No se pudo crear el directorio de las sesiones debido a un error desconocido.</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3379"/>
-        <location filename="../Lektra.cpp" line="3397"/>
-        <location filename="../Lektra.cpp" line="3456"/>
+        <location filename="../Lektra.cpp" line="3779"/>
+        <location filename="../Lektra.cpp" line="3797"/>
+        <location filename="../Lektra.cpp" line="3856"/>
         <source>Save Session</source>
         <translation>Guardar sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3380"/>
+        <location filename="../Lektra.cpp" line="3780"/>
         <source>No files in session to save the session</source>
         <translation>No hay archivos en esta sesión para guardar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3398"/>
+        <location filename="../Lektra.cpp" line="3798"/>
         <source>Session name cannot be empty</source>
         <translation>El nombre de la sesión no puede estar vacío</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3408"/>
-        <location filename="../Lektra.cpp" line="3490"/>
+        <location filename="../Lektra.cpp" line="3808"/>
+        <location filename="../Lektra.cpp" line="3890"/>
         <source>Overwrite Session</source>
         <translation>Sobreescribir sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3409"/>
-        <location filename="../Lektra.cpp" line="3491"/>
+        <location filename="../Lektra.cpp" line="3809"/>
+        <location filename="../Lektra.cpp" line="3891"/>
         <source>Session named &quot;%1&quot; already exists. Do you want to overwrite it?</source>
         <translation>La sesión &quot;%1&quot; ya existe. ¿Deseas sobreescribirla?</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3457"/>
+        <location filename="../Lektra.cpp" line="3857"/>
         <source>Could not save session: %1</source>
         <translation>No se pudo guardar la sesión: %1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3472"/>
-        <location filename="../Lektra.cpp" line="3481"/>
-        <location filename="../Lektra.cpp" line="3505"/>
+        <location filename="../Lektra.cpp" line="3872"/>
+        <location filename="../Lektra.cpp" line="3880"/>
+        <location filename="../Lektra.cpp" line="3905"/>
         <source>Save As Session</source>
         <translation>Guardar como sesión</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3473"/>
+        <location filename="../Lektra.cpp" line="3873"/>
         <source>Cannot save session as you are not currently in a session</source>
         <translation>No se pudo guardar la sesión ya que no te encuentras en una</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3482"/>
+        <location filename="../Lektra.cpp" line="3881"/>
         <source>Lektra session files</source>
         <translation>Archivos de sesión de Lektra</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3506"/>
+        <location filename="../Lektra.cpp" line="3906"/>
         <source>Failed to save session.</source>
         <translation>No se pudo guardar la sesión.</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3533"/>
+        <location filename="../Lektra.cpp" line="3933"/>
         <source>Startup</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3535"/>
-        <location filename="../Lektra.cpp" line="3544"/>
+        <location filename="../Lektra.cpp" line="3935"/>
+        <location filename="../Lektra.cpp" line="3944"/>
         <source>Start Page</source>
         <translation>Página de inicio</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3576"/>
+        <location filename="../Lektra.cpp" line="3978"/>
         <source>Copy current selection to clipboard</source>
         <translation>Copiar selección al portapapeles</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3579"/>
+        <location filename="../Lektra.cpp" line="3981"/>
         <source>Cancel and clear current selection</source>
         <translation>Cancelar y borrar la selección actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3581"/>
+        <location filename="../Lektra.cpp" line="3984"/>
         <source>Reselect the last text selection</source>
         <translation>Volver a seleccionar la última selección de texto</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3586"/>
+        <location filename="../Lektra.cpp" line="3988"/>
         <source>Toggle presentation mode</source>
         <translation>Cambiar modo de presentación</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3589"/>
+        <location filename="../Lektra.cpp" line="3991"/>
         <source>Toggle fullscreen</source>
         <translation>Cambiar a pantalla completa</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3591"/>
+        <location filename="../Lektra.cpp" line="3993"/>
         <source>Open command palette</source>
         <translation>Abrir selector de comandos</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3594"/>
+        <location filename="../Lektra.cpp" line="3996"/>
         <source>Toggle tab bar</source>
         <translation>Mostrar u ocultar la barra de pestañas</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3596"/>
+        <location filename="../Lektra.cpp" line="3998"/>
         <source>Toggle menu bar</source>
         <translation>Mostrar u ocultar la barra del menú</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3598"/>
+        <location filename="../Lektra.cpp" line="4000"/>
         <source>Toggle status bar</source>
         <translation>Mostrar u ocultar la barra de estado</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3600"/>
+        <location filename="../Lektra.cpp" line="4002"/>
         <source>Toggle focus mode</source>
         <translation>Cambiar el modo de enfoque</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3602"/>
+        <location filename="../Lektra.cpp" line="4004"/>
         <source>Toggle visual line mode</source>
         <translation>Activar o desactivar el modo de línea visual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3607"/>
+        <location filename="../Lektra.cpp" line="4008"/>
+        <source>Toggle comment markers</source>
+        <translation>Mostrar u ocultar los marcadores de comentarios</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4012"/>
         <source>Toggle LLM assistant widget</source>
         <translation>Activar o desactivar el widget del asistente LLM</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3612"/>
+        <location filename="../Lektra.cpp" line="4018"/>
         <source>Open link using keyboard hint</source>
         <translation>Abrir enlace usando el atajo de teclado</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3614"/>
+        <location filename="../Lektra.cpp" line="4021"/>
         <source>Copy link URL using keyboard hint</source>
         <translation>Copiar enlace usando el atajo de teclado</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3618"/>
+        <location filename="../Lektra.cpp" line="4025"/>
         <source>Go to first page</source>
         <translation>Ir a la primera página</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3620"/>
+        <location filename="../Lektra.cpp" line="4027"/>
         <source>Go to last page</source>
         <translation>Ir a la última página</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3622"/>
+        <location filename="../Lektra.cpp" line="4029"/>
         <source>Go to next page</source>
         <translation>Ir a la siguiente página</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3624"/>
+        <location filename="../Lektra.cpp" line="4031"/>
         <source>Go to previous page</source>
         <translation>Retroceder a la página anterior</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3626"/>
+        <location filename="../Lektra.cpp" line="4033"/>
         <source>Jump to a specific page number</source>
         <translation>Saltar a una página en específico</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3630"/>
+        <location filename="../Lektra.cpp" line="4039"/>
         <source>Set a named mark at current position</source>
         <translation>Definir un marcador con nombre en esta posición</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3632"/>
+        <location filename="../Lektra.cpp" line="4041"/>
         <source>Delete a named mark</source>
         <translation>Eliminar un marcador con nombre</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3634"/>
+        <location filename="../Lektra.cpp" line="4044"/>
         <source>Jump to a named mark</source>
         <translation>Saltar a un marcador con nombre</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3638"/>
+        <location filename="../Lektra.cpp" line="4048"/>
+        <location filename="../Lektra.cpp" line="4056"/>
         <source>Scroll down</source>
         <translation>Desplazarse hacia abajo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3640"/>
+        <location filename="../Lektra.cpp" line="4050"/>
+        <location filename="../Lektra.cpp" line="4059"/>
         <source>Scroll up</source>
         <translation>Desplazarse hacia arriba</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3642"/>
+        <location filename="../Lektra.cpp" line="4052"/>
         <source>Scroll left</source>
         <translation>Desplazarse hacia la izquierda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3644"/>
+        <location filename="../Lektra.cpp" line="4054"/>
         <source>Scroll right</source>
         <translation>Desplazarse hacia la derecha</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3648"/>
+        <location filename="../Lektra.cpp" line="4064"/>
         <source>Rotate page clockwise</source>
         <translation>Girar la página en sentido horario</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3650"/>
+        <location filename="../Lektra.cpp" line="4067"/>
         <source>Rotate page counter-clockwise</source>
         <translation>Girar la página en sentido antihorario</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3654"/>
+        <location filename="../Lektra.cpp" line="4071"/>
         <source>Go back in location history</source>
         <translation>Retroceder en el historial</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3656"/>
+        <location filename="../Lektra.cpp" line="4074"/>
         <source>Go forward in location history</source>
         <translation>Avanzar en el historial</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3660"/>
+        <location filename="../Lektra.cpp" line="4078"/>
         <source>Zoom in</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3662"/>
+        <location filename="../Lektra.cpp" line="4080"/>
         <source>Zoom out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3664"/>
+        <location filename="../Lektra.cpp" line="4082"/>
         <source>Reset zoom to default</source>
         <translation>Reiniciar el acercamiento</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3666"/>
+        <location filename="../Lektra.cpp" line="4084"/>
         <source>Set zoom to a specific level</source>
         <translation>Acercar a un nivel específico</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3670"/>
+        <location filename="../Lektra.cpp" line="4088"/>
         <source>Split view horizontally</source>
         <translation>Dividir vista horizontalmente</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3672"/>
+        <location filename="../Lektra.cpp" line="4090"/>
         <source>Split view vertically</source>
         <translation>Dividir vista verticalmente</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3674"/>
+        <location filename="../Lektra.cpp" line="4092"/>
         <source>Close current split</source>
         <translation>Cerrar el panel actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3676"/>
+        <location filename="../Lektra.cpp" line="4094"/>
         <source>Focus split to the right</source>
         <translation>Enfocar el panel derecho</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3678"/>
+        <location filename="../Lektra.cpp" line="4097"/>
         <source>Focus split to the left</source>
         <translation>Enfocar el panel izquierdo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3680"/>
+        <location filename="../Lektra.cpp" line="4099"/>
         <source>Focus split above</source>
         <translation>Enfocar el panel superior</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3682"/>
+        <location filename="../Lektra.cpp" line="4101"/>
         <source>Focus split below</source>
         <translation>Enfocar el panel inferior</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3685"/>
+        <location filename="../Lektra.cpp" line="4104"/>
         <source>Close all splits except current</source>
         <translation>Cerrar todos los paneles excepto el actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3689"/>
+        <location filename="../Lektra.cpp" line="4108"/>
         <source>Create or focus portal</source>
         <translation>Crear o enfocar un portal</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3694"/>
+        <location filename="../Lektra.cpp" line="4113"/>
         <source>Open file in new tab</source>
         <translation>Abrir archivo en una pestaña nueva</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3696"/>
+        <location filename="../Lektra.cpp" line="4122"/>
         <source>Open file in vertical split</source>
         <translation>Abrir archivo en un nuevo panel vertical</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3698"/>
+        <location filename="../Lektra.cpp" line="4126"/>
         <source>Open file in horizontal split</source>
         <translation>Abrir archivo en un nuevo panel horizontal</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3700"/>
+        <location filename="../Lektra.cpp" line="4129"/>
         <source>Open file (do what I mean)</source>
         <translation>Abrir archivo (paneles inteligentes)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3702"/>
+        <location filename="../Lektra.cpp" line="4132"/>
         <source>Close current file</source>
         <translation>Cerrar el archivo actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3704"/>
+        <location filename="../Lektra.cpp" line="4135"/>
         <source>Save current file</source>
         <translation>Guardar el archivo actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3706"/>
+        <location filename="../Lektra.cpp" line="4138"/>
         <source>Save current file as a new name</source>
         <translation>Guardar este archivo con un nombre nuevo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3708"/>
+        <location filename="../Lektra.cpp" line="4140"/>
         <source>Encrypt current document</source>
         <translation>Encriptar el documento actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3710"/>
+        <location filename="../Lektra.cpp" line="4142"/>
         <source>Decrypt current document</source>
         <translation>Desencriptar el documento actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3712"/>
+        <location filename="../Lektra.cpp" line="4144"/>
         <source>Reload current file from disk</source>
         <translation>Recargar el archivo actual desde el disco</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3714"/>
+        <location filename="../Lektra.cpp" line="4146"/>
         <source>Show file properties</source>
         <translation>Mostrar propiedades del archivo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3716"/>
+        <location filename="../Lektra.cpp" line="4148"/>
         <source>Show recently opened files</source>
         <translation>Mostrar archivos recientes</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3721"/>
+        <location filename="../Lektra.cpp" line="4154"/>
         <source>Toggle annotation select mode</source>
         <translation>Cambiar el modo de selección de anotaciones</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3723"/>
+        <location filename="../Lektra.cpp" line="4157"/>
         <source>Toggle annotation popup mode</source>
         <translation>Cambiar el modo emergente de anotaciones</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3725"/>
+        <location filename="../Lektra.cpp" line="4160"/>
         <source>Toggle rectangle annotation mode</source>
         <translation>Cambiar el modo de anotaciones rectangulares</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3727"/>
+        <location filename="../Lektra.cpp" line="4163"/>
         <source>Toggle text highlight mode</source>
         <translation>Cambiar modo de resaltado del texto</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3730"/>
+        <location filename="../Lektra.cpp" line="4165"/>
         <source>Toggle none interaction mode</source>
         <translation>Cambiar modo de no interacción</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3735"/>
+        <location filename="../Lektra.cpp" line="4170"/>
         <source>Switch to text selection mode</source>
         <translation>Cambiar a modo de selección de texto</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3738"/>
+        <location filename="../Lektra.cpp" line="4173"/>
         <source>Switch to region selection mode</source>
         <translation>Cambiar a modo de selección de regiones</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3742"/>
+        <location filename="../Lektra.cpp" line="4177"/>
         <source>Fit page to window width</source>
         <translation>Ajustar página al ancho de la ventana</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3744"/>
+        <location filename="../Lektra.cpp" line="4179"/>
         <source>Fit page to window height</source>
         <translation>Ajustar página a lo largo de la ventana</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3746"/>
+        <location filename="../Lektra.cpp" line="4181"/>
         <source>Fit entire page in window</source>
         <translation>Ajustar la página completa en la ventana</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3748"/>
+        <location filename="../Lektra.cpp" line="4183"/>
         <source>Toggle automatic resize to fit</source>
         <translation>Cambiar modo de redimensión automática a ajuste</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3752"/>
+        <location filename="../Lektra.cpp" line="4187"/>
         <source>Save current session</source>
         <translation>Guardar sesión actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3755"/>
+        <location filename="../Lektra.cpp" line="4190"/>
         <source>Save current session under a new name</source>
         <translation>Guardar la sesión actual con un nombre nuevo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3757"/>
+        <location filename="../Lektra.cpp" line="4192"/>
         <source>Load a saved session</source>
         <translation>Cargar una sesión guardada</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3761"/>
+        <location filename="../Lektra.cpp" line="4196"/>
         <source>Close all tabs to the left</source>
         <translation>Cerrar todas las pestañas a la izquierda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3763"/>
+        <location filename="../Lektra.cpp" line="4199"/>
         <source>Close all tabs to the right</source>
         <translation>Cerrar todas las pestañas a la derecha</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3765"/>
+        <location filename="../Lektra.cpp" line="4202"/>
         <source>Close all tabs except current</source>
         <translation>Cerrar todas las pestañas excepto la actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3767"/>
+        <location filename="../Lektra.cpp" line="4204"/>
         <source>Move current tab right</source>
         <translation>Mover la pestaña actual a la derecha</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3769"/>
+        <location filename="../Lektra.cpp" line="4206"/>
         <source>Move current tab left</source>
         <translation>Mover la pestaña actual a la izquierda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3771"/>
+        <location filename="../Lektra.cpp" line="4208"/>
         <source>Switch to first tab</source>
         <translation>Cambiar a la primera pestaña</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3773"/>
+        <location filename="../Lektra.cpp" line="4210"/>
         <source>Switch to last tab</source>
         <translation>Cambiar a la última pestaña</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3775"/>
+        <location filename="../Lektra.cpp" line="4212"/>
         <source>Switch to next tab</source>
         <translation>Cambiar a la pestaña siguiente</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3777"/>
+        <location filename="../Lektra.cpp" line="4214"/>
         <source>Switch to previous tab</source>
         <translation>Cambiar a la pestaña anterior</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3779"/>
+        <location filename="../Lektra.cpp" line="4216"/>
         <source>Close current tab</source>
         <translation>Cerrar la pestaña actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3781"/>
+        <location filename="../Lektra.cpp" line="4218"/>
         <source>Go to tab by number</source>
         <translation>Cambiar a la última pestaña</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3783"/>
+        <location filename="../Lektra.cpp" line="4220"/>
         <source>Switch to tab 1</source>
         <translation>Cambiar a la pestaña 1</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3785"/>
+        <location filename="../Lektra.cpp" line="4222"/>
         <source>Switch to tab 2</source>
         <translation>Cambiar a la pestaña 2</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3787"/>
+        <location filename="../Lektra.cpp" line="4224"/>
         <source>Switch to tab 3</source>
         <translation>Cambiar a la pestaña 3</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3789"/>
+        <location filename="../Lektra.cpp" line="4226"/>
         <source>Switch to tab 4</source>
         <translation>Cambiar a la pestaña 4</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3791"/>
+        <location filename="../Lektra.cpp" line="4228"/>
         <source>Switch to tab 5</source>
         <translation>Cambiar a la pestaña 5</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3793"/>
+        <location filename="../Lektra.cpp" line="4230"/>
         <source>Switch to tab 6</source>
         <translation>Cambiar a la pestaña 6</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3795"/>
+        <location filename="../Lektra.cpp" line="4232"/>
         <source>Switch to tab 7</source>
         <translation>Cambiar a la pestaña 7</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3797"/>
+        <location filename="../Lektra.cpp" line="4234"/>
         <source>Switch to tab 8</source>
         <translation>Cambiar a la pestaña 8</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3799"/>
+        <location filename="../Lektra.cpp" line="4236"/>
         <source>Switch to tab 9</source>
         <translation>Cambiar a la pestaña 9</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3803"/>
+        <location filename="../Lektra.cpp" line="4240"/>
         <source>Open document outline picker</source>
         <translation>Abrir selector de índice del documento</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3805"/>
+        <location filename="../Lektra.cpp" line="4243"/>
         <source>Search within highlights</source>
         <translation>Buscar dentro de los resaltados</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3812"/>
+        <location filename="../Lektra.cpp" line="4247"/>
+        <source>Search annotation comments</source>
+        <translation>Buscar comentarios de anotación</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4251"/>
+        <source>Search document</source>
+        <translation>Buscar en el documento</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4253"/>
         <source>Search document using regex</source>
         <translation>Buscar en el documento usando expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3814"/>
+        <location filename="../Lektra.cpp" line="4257"/>
+        <source>Search from current position</source>
+        <translation>Buscar desde la posición actual</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4259"/>
         <source>Jump to next search result</source>
         <translation>Ir al siguiente resultado de búsqueda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3816"/>
+        <location filename="../Lektra.cpp" line="4261"/>
         <source>Jump to previous search result</source>
         <translation>Ir al resultado anterior de búsqueda</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3818"/>
+        <location filename="../Lektra.cpp" line="4264"/>
         <source>Search with inline query argument</source>
         <translation>Buscar con argumento en línea</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3823"/>
+        <location filename="../Lektra.cpp" line="4267"/>
+        <source>Cancel current search and clear highlights</source>
+        <translation>Cancelar la búsqueda actual y quitar los resaltados</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4271"/>
         <source>Single page layout</source>
         <translation>Disposición de una sola página</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3827"/>
+        <location filename="../Lektra.cpp" line="4275"/>
         <source>Horizontal (left to right) layout</source>
         <translation>Disposición horizontal (de izquierda a derecha)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3830"/>
+        <location filename="../Lektra.cpp" line="4279"/>
         <source>Vertical (top to bottom) layout</source>
         <translation>Disposición vertical (de arriba a abajo)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3833"/>
+        <location filename="../Lektra.cpp" line="4282"/>
         <source>Book (two page spread) layout</source>
         <translation>Disposición tipo libro (doble página)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3838"/>
+        <location filename="../Lektra.cpp" line="4287"/>
+        <source>Show the preview window</source>
+        <translation>Mostrar la ventana de previsualización</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4296"/>
+        <source>Open configuration file</source>
+        <translation>Abrir archivo de configuración</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4299"/>
         <source>Set device pixel ratio</source>
         <translation>Establecer la relación de píxeles del dispositivo</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3841"/>
+        <location filename="../Lektra.cpp" line="4302"/>
         <source>Open folder containing current file</source>
         <translation>Abrir la carpeta que contiene el archivo actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3843"/>
+        <location filename="../Lektra.cpp" line="4304"/>
         <source>Undo last action</source>
         <translation>Deshacer la última acción</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3845"/>
+        <location filename="../Lektra.cpp" line="4306"/>
         <source>Redo last undone action</source>
         <translation>Rehacer la última acción deshecha</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3848"/>
+        <location filename="../Lektra.cpp" line="4309"/>
         <source>Highlight current text selection</source>
         <translation>Resaltar la selección de texto actual</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3850"/>
+        <location filename="../Lektra.cpp" line="4312"/>
         <source>Toggle inverted colour rendering</source>
         <translation>Colores invertidos</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3852"/>
+        <location filename="../Lektra.cpp" line="4315"/>
         <source>Re-show the last jump marker</source>
         <translation>Volver a mostrar el último marcador de salto</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3855"/>
+        <location filename="../Lektra.cpp" line="4318"/>
         <source>Reopen last closed file</source>
         <translation>Volver a abrir el último archivo cerrado</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3858"/>
+        <location filename="../Lektra.cpp" line="4320"/>
         <source>Copy current page as image</source>
         <translation>Copiar la página actual como imagen</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3861"/>
+        <location filename="../Lektra.cpp" line="4323"/>
         <source>Run debug command</source>
         <translation>Ejecutar comando de depuración</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3866"/>
+        <location filename="../Lektra.cpp" line="4328"/>
         <source>Show startup screen</source>
         <translation>Mostrar la pantalla de inicio</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3868"/>
+        <location filename="../Lektra.cpp" line="4331"/>
         <source>Open tutorial document</source>
         <translation>Abrir el documento del tutorial</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3870"/>
+        <location filename="../Lektra.cpp" line="4333"/>
         <source>Show about dialog</source>
         <translation>Mostrar el cuadro de diálogo «Acerca de»</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3885"/>
+        <location filename="../Lektra.cpp" line="4348"/>
         <source>Failed to trim recent files store</source>
         <translation>No se pudo depurar la lista de archivos recientes</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3897"/>
-        <location filename="../Lektra.cpp" line="3902"/>
+        <location filename="../Lektra.cpp" line="4360"/>
+        <location filename="../Lektra.cpp" line="4366"/>
         <source>Set DPR</source>
         <translation>Establecer la relación de píxeles (DPR)</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3897"/>
+        <location filename="../Lektra.cpp" line="4361"/>
         <source>Enter the Device Pixel Ratio (DPR) value: </source>
         <translation>Introducir el valor de la relación de píxeles (DPR): </translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3966"/>
+        <location filename="../Lektra.cpp" line="4430"/>
         <source>Go to Tab</source>
         <translation>Ir a la pestaña</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3966"/>
+        <location filename="../Lektra.cpp" line="4431"/>
         <source>Enter tab number: </source>
         <translation>Introducir número de pestaña: </translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3973"/>
+        <location filename="../Lektra.cpp" line="4438"/>
         <source>Invalid Tab Number</source>
         <translation>Número de pestaña no válido</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4283"/>
+        <location filename="../Lektra.cpp" line="4661"/>
+        <source>Search Not Supported</source>
+        <translation>Búsqueda no soportada</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4662"/>
+        <source>The current document does not support text search.</source>
+        <translation>Este documento no soporta la búsqueda por texto.</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4797"/>
         <source>Select Color</source>
         <translation>Seleccionar color</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4320"/>
+        <location filename="../Lektra.cpp" line="4834"/>
         <source>Escape key pressed handled</source>
         <translation>Pulsación de la tecla Escape gestionada</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4364"/>
+        <location filename="../Lektra.cpp" line="4881"/>
         <source>Show Tutorial File</source>
         <translation>Mostrar el archivo del tutorial</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4365"/>
-        <source>Not yet implemented for Mac</source>
-        <translation>Aún no implementado para Mac</translation>
+        <location filename="../Lektra.cpp" line="4882"/>
+        <source>Tutorial file could not be found.</source>
+        <translation>No se encontró el archivo del tutorial.</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4368"/>
+        <location filename="../Lektra.cpp" line="5799"/>
+        <source>Config file not found at:
+%1</source>
+        <translation>No se encontró el archivo de configuración: %1</translation>
+    </message>
+    <message>
+        <source>Not yet implemented for Mac</source>
+        <translation type="vanished">Aún no implementado para Mac</translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4885"/>
         <source>Not yet implemented for Windows</source>
         <translation>Aún no implementado para Windows</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4964"/>
+        <location filename="../Lektra.cpp" line="5536"/>
         <source>No recent files found.</source>
         <translation>No se encontraron archivos recientes.</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5022"/>
+        <location filename="../Lektra.cpp" line="5596"/>
         <source>Reopen_last_file: file no longer exists:</source>
         <translation>Volver a abrir el último archivo: el archivo ya no existe:</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5040"/>
-        <location filename="../Lektra.cpp" line="5044"/>
+        <location filename="../Lektra.cpp" line="5619"/>
+        <location filename="../Lektra.cpp" line="5624"/>
         <source>Set Mark</source>
         <translation>Establecer marcador</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5040"/>
+        <location filename="../Lektra.cpp" line="5620"/>
         <source>Enter mark key (a-z for local, A-Z for global):</source>
         <translation>Introducir tecla de marcador (a-z para local, A-Z para global):</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5044"/>
-        <location filename="../Lektra.cpp" line="5068"/>
-        <location filename="../Lektra.cpp" line="5094"/>
+        <location filename="../Lektra.cpp" line="5625"/>
+        <location filename="../Lektra.cpp" line="5658"/>
+        <location filename="../Lektra.cpp" line="5690"/>
         <source>Mark key cannot be empty</source>
         <translation>La tecla de marcador no puede estar vacía</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5064"/>
-        <location filename="../Lektra.cpp" line="5068"/>
+        <location filename="../Lektra.cpp" line="5652"/>
+        <location filename="../Lektra.cpp" line="5657"/>
         <source>Delete Mark</source>
         <translation>Eliminar marcador</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5064"/>
+        <location filename="../Lektra.cpp" line="5653"/>
         <source>Mark to delete:</source>
         <translation>Marcador a eliminar:</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5090"/>
-        <location filename="../Lektra.cpp" line="5094"/>
+        <location filename="../Lektra.cpp" line="5684"/>
+        <location filename="../Lektra.cpp" line="5689"/>
         <source>Goto Mark</source>
         <translation>Ir al marcador</translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5090"/>
+        <location filename="../Lektra.cpp" line="5684"/>
         <source>Mark to go to:</source>
         <translation>Marcador al que ir:</translation>
     </message>
@@ -1451,13 +1513,13 @@ Cargando configuración predeterminada.</translation>
 <context>
     <name>OutlinePicker</name>
     <message>
-        <location filename="../OutlinePicker.cpp" line="11"/>
-        <location filename="../OutlinePicker.cpp" line="16"/>
+        <location filename="../OutlinePicker.cpp" line="13"/>
+        <location filename="../OutlinePicker.cpp" line="18"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../OutlinePicker.cpp" line="12"/>
+        <location filename="../OutlinePicker.cpp" line="14"/>
         <source>Page</source>
         <translation>Página</translation>
     </message>
@@ -1465,12 +1527,12 @@ Cargando configuración predeterminada.</translation>
 <context>
     <name>PopupAnnotation</name>
     <message>
-        <location filename="../Annotations/PopupAnnotation.hpp" line="105"/>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="108"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../Annotations/PopupAnnotation.hpp" line="106"/>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="109"/>
         <source>Comment</source>
         <translation>Comentar</translation>
     </message>
@@ -1491,19 +1553,62 @@ Cargando configuración predeterminada.</translation>
 <context>
     <name>RectAnnotation</name>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="85"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="86"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="88"/>
         <source>Change Color</source>
         <translation>Cambiar color</translation>
     </message>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="89"/>
         <source>Comment</source>
         <translation>Comentar</translation>
+    </message>
+</context>
+<context>
+    <name>SearchBar</name>
+    <message>
+        <location filename="../SearchBar.cpp" line="16"/>
+        <source>Search:</source>
+        <translation>Buscar:</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="26"/>
+        <source>Regular Expression</source>
+        <translation>Expresión regular</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="31"/>
+        <source>Goto Next Hit</source>
+        <translation>Siguiente coincidencia</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="32"/>
+        <source>Goto Previous Hit</source>
+        <translation>Coincidencia anterior</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="33"/>
+        <source>Close Search Bar</source>
+        <translation>Cerrar la barra de búsqueda</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="55"/>
+        <source>Search query…</source>
+        <translation>Búsqueda…</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="82"/>
+        <source>Invalid Index</source>
+        <translation>Índice inválido</translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="83"/>
+        <source>Please enter a valid search index.</source>
+        <translation>Por favor, introduce un índice de búsqueda válido.</translation>
     </message>
 </context>
 <context>
@@ -1514,37 +1619,37 @@ Cargando configuración predeterminada.</translation>
         <translation>de</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="120"/>
+        <location filename="../Statusbar.cpp" line="137"/>
         <source>Region Selection</source>
         <translation>Selección de región</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="127"/>
+        <location filename="../Statusbar.cpp" line="144"/>
         <source>Text Selection</source>
         <translation>Selección de texto</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="134"/>
+        <location filename="../Statusbar.cpp" line="151"/>
         <source>Text Highlight</source>
         <translation>Resaltado de texto</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="141"/>
+        <location filename="../Statusbar.cpp" line="158"/>
         <source>Annot Select</source>
         <translation>Selección de anotaciones</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="148"/>
+        <location filename="../Statusbar.cpp" line="165"/>
         <source>Annot Rect</source>
         <translation>Anotación rectangular</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="155"/>
+        <location filename="../Statusbar.cpp" line="172"/>
         <source>Annot Popup</source>
         <translation>Anotación emergente</translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="162"/>
+        <location filename="../Statusbar.cpp" line="179"/>
         <source>Visual Line</source>
         <translation>Línea visual</translation>
     </message>

--- a/src/Translations/lektra.ts
+++ b/src/Translations/lektra.ts
@@ -33,72 +33,82 @@
 <context>
     <name>DocumentView</name>
     <message>
-        <location filename="../DocumentView.cpp" line="532"/>
+        <location filename="../DocumentView.cpp" line="307"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="308"/>
+        <source>Failed to open the file. Please check if the file exists and is a supported format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../DocumentView.cpp" line="605"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="533"/>
+        <location filename="../DocumentView.cpp" line="606"/>
         <source>No matches found for the given term.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3453"/>
+        <location filename="../DocumentView.cpp" line="3724"/>
         <source>Add Comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3453"/>
+        <location filename="../DocumentView.cpp" line="3724"/>
         <source>Enter annotation comment:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3996"/>
+        <location filename="../DocumentView.cpp" line="4281"/>
         <source>Save Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3997"/>
+        <location filename="../DocumentView.cpp" line="4282"/>
         <source>PNG Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3998"/>
+        <location filename="../DocumentView.cpp" line="4282"/>
         <source>JPEG Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="3999"/>
+        <location filename="../DocumentView.cpp" line="4283"/>
         <source>BMP Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4222"/>
+        <location filename="../DocumentView.cpp" line="4505"/>
         <source>Add Note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4222"/>
+        <location filename="../DocumentView.cpp" line="4505"/>
         <source>Enter annotation text:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4456"/>
+        <location filename="../DocumentView.cpp" line="4721"/>
         <source>Password Required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4456"/>
+        <location filename="../DocumentView.cpp" line="4721"/>
         <source>Enter password:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4475"/>
+        <location filename="../DocumentView.cpp" line="4740"/>
         <source>Incorrect Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DocumentView.cpp" line="4476"/>
+        <location filename="../DocumentView.cpp" line="4741"/>
         <source>The password you entered is incorrect.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -162,17 +172,17 @@
 <context>
     <name>HighlightAnnotation</name>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="105"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="97"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="106"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="98"/>
         <source>Change Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Annotations/HighlightAnnotation.hpp" line="107"/>
+        <location filename="../Annotations/HighlightAnnotation.hpp" line="99"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -180,358 +190,358 @@
 <context>
     <name>Lektra</name>
     <message>
-        <location filename="../Lektra.cpp" line="118"/>
+        <location filename="../Lektra.cpp" line="139"/>
         <source>&amp;File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="121"/>
+        <location filename="../Lektra.cpp" line="142"/>
         <source>Open File	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="124"/>
+        <location filename="../Lektra.cpp" line="145"/>
         <source>Open File In VSplit	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="128"/>
+        <location filename="../Lektra.cpp" line="149"/>
         <source>Open File In HSplit	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="132"/>
-        <location filename="../Lektra.cpp" line="4963"/>
+        <location filename="../Lektra.cpp" line="153"/>
+        <location filename="../Lektra.cpp" line="5535"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="135"/>
+        <location filename="../Lektra.cpp" line="156"/>
         <source>File Properties	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="140"/>
+        <location filename="../Lektra.cpp" line="160"/>
         <source>Open Containing Folder	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="146"/>
+        <location filename="../Lektra.cpp" line="166"/>
         <source>Save File	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="150"/>
+        <location filename="../Lektra.cpp" line="170"/>
         <source>Save As File	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="153"/>
+        <location filename="../Lektra.cpp" line="173"/>
         <source>Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="156"/>
+        <location filename="../Lektra.cpp" line="176"/>
         <source>Save	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="159"/>
+        <location filename="../Lektra.cpp" line="179"/>
         <source>Save As	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="162"/>
+        <location filename="../Lektra.cpp" line="182"/>
         <source>Load	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="168"/>
+        <location filename="../Lektra.cpp" line="188"/>
         <source>Close File	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="172"/>
+        <location filename="../Lektra.cpp" line="192"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="174"/>
+        <location filename="../Lektra.cpp" line="194"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="176"/>
+        <location filename="../Lektra.cpp" line="196"/>
         <source>Undo	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="179"/>
+        <location filename="../Lektra.cpp" line="198"/>
         <source>Redo	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="184"/>
+        <location filename="../Lektra.cpp" line="202"/>
         <source>Last Pages	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="188"/>
+        <location filename="../Lektra.cpp" line="206"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="190"/>
+        <location filename="../Lektra.cpp" line="208"/>
         <source>Fullscreen	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="196"/>
+        <location filename="../Lektra.cpp" line="214"/>
         <source>Zoom In	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="199"/>
+        <location filename="../Lektra.cpp" line="217"/>
         <source>Zoom Out	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="204"/>
+        <location filename="../Lektra.cpp" line="222"/>
         <source>Fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="207"/>
+        <location filename="../Lektra.cpp" line="225"/>
         <source>Width	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="211"/>
+        <location filename="../Lektra.cpp" line="229"/>
         <source>Height	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="215"/>
+        <location filename="../Lektra.cpp" line="233"/>
         <source>Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="222"/>
+        <location filename="../Lektra.cpp" line="240"/>
         <source>Auto Fit	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="231"/>
+        <location filename="../Lektra.cpp" line="249"/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="236"/>
+        <location filename="../Lektra.cpp" line="254"/>
         <source>Single Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="240"/>
+        <location filename="../Lektra.cpp" line="258"/>
         <source>Left to Right Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="245"/>
+        <location filename="../Lektra.cpp" line="263"/>
         <source>Top to Bottom Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="250"/>
+        <location filename="../Lektra.cpp" line="267"/>
         <source>Book	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="275"/>
+        <location filename="../Lektra.cpp" line="292"/>
         <source>Show/Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="279"/>
+        <location filename="../Lektra.cpp" line="296"/>
         <source>LLM Widget	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="286"/>
+        <location filename="../Lektra.cpp" line="303"/>
         <source>Command Picker	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="290"/>
+        <location filename="../Lektra.cpp" line="307"/>
         <source>Outline	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="297"/>
+        <location filename="../Lektra.cpp" line="311"/>
         <source>Highlight Annotation Search	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="305"/>
+        <location filename="../Lektra.cpp" line="316"/>
         <source>Menubar	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="311"/>
+        <location filename="../Lektra.cpp" line="322"/>
         <source>Tabs	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="317"/>
+        <location filename="../Lektra.cpp" line="328"/>
         <source>Statusbar	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="323"/>
+        <location filename="../Lektra.cpp" line="334"/>
         <source>Invert Color	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="330"/>
+        <location filename="../Lektra.cpp" line="341"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="332"/>
+        <location filename="../Lektra.cpp" line="343"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="338"/>
+        <location filename="../Lektra.cpp" line="349"/>
         <source>Region Selection	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="345"/>
+        <location filename="../Lektra.cpp" line="356"/>
         <source>Text Selection	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="352"/>
+        <location filename="../Lektra.cpp" line="362"/>
         <source>Text Highlight	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="359"/>
+        <location filename="../Lektra.cpp" line="368"/>
         <source>Annotate Rectangle	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="366"/>
+        <location filename="../Lektra.cpp" line="374"/>
         <source>Edit Annotations	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="373"/>
+        <location filename="../Lektra.cpp" line="380"/>
         <source>Annotate Popup	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="381"/>
+        <location filename="../Lektra.cpp" line="387"/>
         <source>Visual Line Mode	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="388"/>
+        <location filename="../Lektra.cpp" line="393"/>
         <source>None	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="427"/>
+        <location filename="../Lektra.cpp" line="432"/>
         <source>Encrypt Document	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="432"/>
+        <location filename="../Lektra.cpp" line="437"/>
         <source>Decrypt Document	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="437"/>
+        <location filename="../Lektra.cpp" line="442"/>
         <source>&amp;Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="440"/>
+        <location filename="../Lektra.cpp" line="445"/>
         <source>StartPage	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="444"/>
+        <location filename="../Lektra.cpp" line="449"/>
         <source>Goto Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="448"/>
+        <location filename="../Lektra.cpp" line="453"/>
         <source>First Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="452"/>
+        <location filename="../Lektra.cpp" line="457"/>
         <source>Previous Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="456"/>
+        <location filename="../Lektra.cpp" line="461"/>
         <source>Next Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="459"/>
+        <location filename="../Lektra.cpp" line="464"/>
         <source>Last Page	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="463"/>
+        <location filename="../Lektra.cpp" line="468"/>
         <source>Previous Location	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="467"/>
+        <location filename="../Lektra.cpp" line="471"/>
         <source>Next Location	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="470"/>
+        <location filename="../Lektra.cpp" line="474"/>
         <source>Marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="473"/>
+        <location filename="../Lektra.cpp" line="477"/>
         <source>Set Mark	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="477"/>
+        <location filename="../Lektra.cpp" line="481"/>
         <source>Goto Mark	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="481"/>
+        <location filename="../Lektra.cpp" line="485"/>
         <source>Delete Mark	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="485"/>
+        <location filename="../Lektra.cpp" line="489"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="487"/>
+        <location filename="../Lektra.cpp" line="491"/>
         <source>About	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="491"/>
+        <location filename="../Lektra.cpp" line="495"/>
         <source>Open Tutorial File	%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="535"/>
+        <location filename="../Lektra.cpp" line="539"/>
         <source>There are one or more error(s) in your config file:
 %1
 
@@ -539,895 +549,943 @@ Loading default config.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1121"/>
+        <location filename="../Lektra.cpp" line="1214"/>
         <source>%1 -&gt; %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1131"/>
+        <location filename="../Lektra.cpp" line="1224"/>
         <source>Shortcut conflict(s): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1135"/>
+        <location filename="../Lektra.cpp" line="1228"/>
         <source>Shortcut conflict(s): %1; and %2 more</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1178"/>
+        <location filename="../Lektra.cpp" line="1273"/>
         <source>LLM: Unknown action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1623"/>
+        <location filename="../Lektra.cpp" line="1902"/>
         <source>Enter page number (1 to %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1632"/>
+        <location filename="../Lektra.cpp" line="1917"/>
         <source>Page %1 is out of range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1822"/>
-        <location filename="../Lektra.cpp" line="1993"/>
-        <location filename="../Lektra.cpp" line="2111"/>
-        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="2502"/>
         <source>PDF Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1822"/>
-        <location filename="../Lektra.cpp" line="1993"/>
-        <location filename="../Lektra.cpp" line="2111"/>
-        <location filename="../Lektra.cpp" line="2202"/>
-        <location filename="../Lektra.cpp" line="3482"/>
+        <location filename="../Lektra.cpp" line="2503"/>
+        <location filename="../Lektra.cpp" line="3881"/>
         <source>All Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1837"/>
-        <location filename="../Lektra.cpp" line="2008"/>
-        <location filename="../Lektra.cpp" line="4695"/>
+        <location filename="../Lektra.cpp" line="2136"/>
+        <location filename="../Lektra.cpp" line="2292"/>
+        <location filename="../Lektra.cpp" line="5179"/>
+        <location filename="../Lektra.cpp" line="5798"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="1838"/>
-        <location filename="../Lektra.cpp" line="2009"/>
-        <location filename="../Lektra.cpp" line="4696"/>
+        <location filename="../Lektra.cpp" line="2137"/>
+        <location filename="../Lektra.cpp" line="2293"/>
+        <location filename="../Lektra.cpp" line="5180"/>
         <source>The specified file does not exist:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2202"/>
+        <location filename="../Lektra.cpp" line="2501"/>
         <source>Open File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2239"/>
+        <location filename="../Lektra.cpp" line="2541"/>
         <source>Unable to find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2784"/>
+        <location filename="../Lektra.cpp" line="3157"/>
         <source>File %1 has unsaved changes. Do you want to save them?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2807"/>
+        <location filename="../Lektra.cpp" line="3180"/>
         <source>Confirm Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2807"/>
+        <location filename="../Lektra.cpp" line="3181"/>
         <source>Are you sure you want to quit Lektra?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2924"/>
+        <location filename="../Lektra.cpp" line="3345"/>
         <source>Open Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2926"/>
+        <location filename="../Lektra.cpp" line="3347"/>
         <source>File Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2929"/>
+        <location filename="../Lektra.cpp" line="3350"/>
         <source>Move Tab to New Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="2936"/>
+        <location filename="../Lektra.cpp" line="3357"/>
         <source>Close Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3287"/>
-        <location filename="../Lektra.cpp" line="3295"/>
+        <location filename="../Lektra.cpp" line="3686"/>
+        <location filename="../Lektra.cpp" line="3695"/>
         <source>Load Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3287"/>
+        <location filename="../Lektra.cpp" line="3687"/>
         <source>No sessions found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3296"/>
+        <location filename="../Lektra.cpp" line="3696"/>
         <source>Session to load (existing sessions are listed): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3309"/>
-        <location filename="../Lektra.cpp" line="3319"/>
+        <location filename="../Lektra.cpp" line="3709"/>
+        <location filename="../Lektra.cpp" line="3719"/>
         <source>Session File Parse Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3312"/>
+        <location filename="../Lektra.cpp" line="3712"/>
         <source>JSON parse error:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3320"/>
-        <location filename="../Lektra.cpp" line="3322"/>
+        <location filename="../Lektra.cpp" line="3720"/>
+        <location filename="../Lektra.cpp" line="3722"/>
         <source>Session file root is not an array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3344"/>
+        <location filename="../Lektra.cpp" line="3744"/>
         <source>Open Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3345"/>
+        <location filename="../Lektra.cpp" line="3745"/>
         <source>Could not open session: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3360"/>
+        <location filename="../Lektra.cpp" line="3759"/>
         <source>Session Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3361"/>
+        <location filename="../Lektra.cpp" line="3760"/>
         <source>Unable to create sessions directory due to an unknown error.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3379"/>
-        <location filename="../Lektra.cpp" line="3397"/>
-        <location filename="../Lektra.cpp" line="3456"/>
+        <location filename="../Lektra.cpp" line="3779"/>
+        <location filename="../Lektra.cpp" line="3797"/>
+        <location filename="../Lektra.cpp" line="3856"/>
         <source>Save Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3380"/>
+        <location filename="../Lektra.cpp" line="3780"/>
         <source>No files in session to save the session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3398"/>
+        <location filename="../Lektra.cpp" line="3798"/>
         <source>Session name cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3408"/>
-        <location filename="../Lektra.cpp" line="3490"/>
+        <location filename="../Lektra.cpp" line="3808"/>
+        <location filename="../Lektra.cpp" line="3890"/>
         <source>Overwrite Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3409"/>
-        <location filename="../Lektra.cpp" line="3491"/>
+        <location filename="../Lektra.cpp" line="3809"/>
+        <location filename="../Lektra.cpp" line="3891"/>
         <source>Session named &quot;%1&quot; already exists. Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3457"/>
+        <location filename="../Lektra.cpp" line="3857"/>
         <source>Could not save session: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3472"/>
-        <location filename="../Lektra.cpp" line="3481"/>
-        <location filename="../Lektra.cpp" line="3505"/>
+        <location filename="../Lektra.cpp" line="3872"/>
+        <location filename="../Lektra.cpp" line="3880"/>
+        <location filename="../Lektra.cpp" line="3905"/>
         <source>Save As Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3473"/>
+        <location filename="../Lektra.cpp" line="3873"/>
         <source>Cannot save session as you are not currently in a session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3482"/>
+        <location filename="../Lektra.cpp" line="3881"/>
         <source>Lektra session files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3506"/>
+        <location filename="../Lektra.cpp" line="3906"/>
         <source>Failed to save session.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3533"/>
+        <location filename="../Lektra.cpp" line="3933"/>
         <source>Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3535"/>
-        <location filename="../Lektra.cpp" line="3544"/>
+        <location filename="../Lektra.cpp" line="3935"/>
+        <location filename="../Lektra.cpp" line="3944"/>
         <source>Start Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3576"/>
+        <location filename="../Lektra.cpp" line="3978"/>
         <source>Copy current selection to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3579"/>
+        <location filename="../Lektra.cpp" line="3981"/>
         <source>Cancel and clear current selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3581"/>
+        <location filename="../Lektra.cpp" line="3984"/>
         <source>Reselect the last text selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3586"/>
+        <location filename="../Lektra.cpp" line="3988"/>
         <source>Toggle presentation mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3589"/>
+        <location filename="../Lektra.cpp" line="3991"/>
         <source>Toggle fullscreen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3591"/>
+        <location filename="../Lektra.cpp" line="3993"/>
         <source>Open command palette</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3594"/>
+        <location filename="../Lektra.cpp" line="3996"/>
         <source>Toggle tab bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3596"/>
+        <location filename="../Lektra.cpp" line="3998"/>
         <source>Toggle menu bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3598"/>
+        <location filename="../Lektra.cpp" line="4000"/>
         <source>Toggle status bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3600"/>
+        <location filename="../Lektra.cpp" line="4002"/>
         <source>Toggle focus mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3602"/>
+        <location filename="../Lektra.cpp" line="4004"/>
         <source>Toggle visual line mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3607"/>
+        <location filename="../Lektra.cpp" line="4008"/>
+        <source>Toggle comment markers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4012"/>
         <source>Toggle LLM assistant widget</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3612"/>
+        <location filename="../Lektra.cpp" line="4018"/>
         <source>Open link using keyboard hint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3614"/>
+        <location filename="../Lektra.cpp" line="4021"/>
         <source>Copy link URL using keyboard hint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3618"/>
+        <location filename="../Lektra.cpp" line="4025"/>
         <source>Go to first page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3620"/>
+        <location filename="../Lektra.cpp" line="4027"/>
         <source>Go to last page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3622"/>
+        <location filename="../Lektra.cpp" line="4029"/>
         <source>Go to next page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3624"/>
+        <location filename="../Lektra.cpp" line="4031"/>
         <source>Go to previous page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3626"/>
+        <location filename="../Lektra.cpp" line="4033"/>
         <source>Jump to a specific page number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3630"/>
+        <location filename="../Lektra.cpp" line="4039"/>
         <source>Set a named mark at current position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3632"/>
+        <location filename="../Lektra.cpp" line="4041"/>
         <source>Delete a named mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3634"/>
+        <location filename="../Lektra.cpp" line="4044"/>
         <source>Jump to a named mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3638"/>
+        <location filename="../Lektra.cpp" line="4048"/>
+        <location filename="../Lektra.cpp" line="4056"/>
         <source>Scroll down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3640"/>
+        <location filename="../Lektra.cpp" line="4050"/>
+        <location filename="../Lektra.cpp" line="4059"/>
         <source>Scroll up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3642"/>
+        <location filename="../Lektra.cpp" line="4052"/>
         <source>Scroll left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3644"/>
+        <location filename="../Lektra.cpp" line="4054"/>
         <source>Scroll right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3648"/>
+        <location filename="../Lektra.cpp" line="4064"/>
         <source>Rotate page clockwise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3650"/>
+        <location filename="../Lektra.cpp" line="4067"/>
         <source>Rotate page counter-clockwise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3654"/>
+        <location filename="../Lektra.cpp" line="4071"/>
         <source>Go back in location history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3656"/>
+        <location filename="../Lektra.cpp" line="4074"/>
         <source>Go forward in location history</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3660"/>
+        <location filename="../Lektra.cpp" line="4078"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3662"/>
+        <location filename="../Lektra.cpp" line="4080"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3664"/>
+        <location filename="../Lektra.cpp" line="4082"/>
         <source>Reset zoom to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3666"/>
+        <location filename="../Lektra.cpp" line="4084"/>
         <source>Set zoom to a specific level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3670"/>
+        <location filename="../Lektra.cpp" line="4088"/>
         <source>Split view horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3672"/>
+        <location filename="../Lektra.cpp" line="4090"/>
         <source>Split view vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3674"/>
+        <location filename="../Lektra.cpp" line="4092"/>
         <source>Close current split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3676"/>
+        <location filename="../Lektra.cpp" line="4094"/>
         <source>Focus split to the right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3678"/>
+        <location filename="../Lektra.cpp" line="4097"/>
         <source>Focus split to the left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3680"/>
+        <location filename="../Lektra.cpp" line="4099"/>
         <source>Focus split above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3682"/>
+        <location filename="../Lektra.cpp" line="4101"/>
         <source>Focus split below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3685"/>
+        <location filename="../Lektra.cpp" line="4104"/>
         <source>Close all splits except current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3689"/>
+        <location filename="../Lektra.cpp" line="4108"/>
         <source>Create or focus portal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3694"/>
+        <location filename="../Lektra.cpp" line="4113"/>
         <source>Open file in new tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3696"/>
+        <location filename="../Lektra.cpp" line="4122"/>
         <source>Open file in vertical split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3698"/>
+        <location filename="../Lektra.cpp" line="4126"/>
         <source>Open file in horizontal split</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3700"/>
+        <location filename="../Lektra.cpp" line="4129"/>
         <source>Open file (do what I mean)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3702"/>
+        <location filename="../Lektra.cpp" line="4132"/>
         <source>Close current file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3704"/>
+        <location filename="../Lektra.cpp" line="4135"/>
         <source>Save current file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3706"/>
+        <location filename="../Lektra.cpp" line="4138"/>
         <source>Save current file as a new name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3708"/>
+        <location filename="../Lektra.cpp" line="4140"/>
         <source>Encrypt current document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3710"/>
+        <location filename="../Lektra.cpp" line="4142"/>
         <source>Decrypt current document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3712"/>
+        <location filename="../Lektra.cpp" line="4144"/>
         <source>Reload current file from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3714"/>
+        <location filename="../Lektra.cpp" line="4146"/>
         <source>Show file properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3716"/>
+        <location filename="../Lektra.cpp" line="4148"/>
         <source>Show recently opened files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3721"/>
+        <location filename="../Lektra.cpp" line="4154"/>
         <source>Toggle annotation select mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3723"/>
+        <location filename="../Lektra.cpp" line="4157"/>
         <source>Toggle annotation popup mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3725"/>
+        <location filename="../Lektra.cpp" line="4160"/>
         <source>Toggle rectangle annotation mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3727"/>
+        <location filename="../Lektra.cpp" line="4163"/>
         <source>Toggle text highlight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3730"/>
+        <location filename="../Lektra.cpp" line="4165"/>
         <source>Toggle none interaction mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3735"/>
+        <location filename="../Lektra.cpp" line="4170"/>
         <source>Switch to text selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3738"/>
+        <location filename="../Lektra.cpp" line="4173"/>
         <source>Switch to region selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3742"/>
+        <location filename="../Lektra.cpp" line="4177"/>
         <source>Fit page to window width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3744"/>
+        <location filename="../Lektra.cpp" line="4179"/>
         <source>Fit page to window height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3746"/>
+        <location filename="../Lektra.cpp" line="4181"/>
         <source>Fit entire page in window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3748"/>
+        <location filename="../Lektra.cpp" line="4183"/>
         <source>Toggle automatic resize to fit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3752"/>
+        <location filename="../Lektra.cpp" line="4187"/>
         <source>Save current session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3755"/>
+        <location filename="../Lektra.cpp" line="4190"/>
         <source>Save current session under a new name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3757"/>
+        <location filename="../Lektra.cpp" line="4192"/>
         <source>Load a saved session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3761"/>
+        <location filename="../Lektra.cpp" line="4196"/>
         <source>Close all tabs to the left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3763"/>
+        <location filename="../Lektra.cpp" line="4199"/>
         <source>Close all tabs to the right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3765"/>
+        <location filename="../Lektra.cpp" line="4202"/>
         <source>Close all tabs except current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3767"/>
+        <location filename="../Lektra.cpp" line="4204"/>
         <source>Move current tab right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3769"/>
+        <location filename="../Lektra.cpp" line="4206"/>
         <source>Move current tab left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3771"/>
+        <location filename="../Lektra.cpp" line="4208"/>
         <source>Switch to first tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3773"/>
+        <location filename="../Lektra.cpp" line="4210"/>
         <source>Switch to last tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3775"/>
+        <location filename="../Lektra.cpp" line="4212"/>
         <source>Switch to next tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3777"/>
+        <location filename="../Lektra.cpp" line="4214"/>
         <source>Switch to previous tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3779"/>
+        <location filename="../Lektra.cpp" line="4216"/>
         <source>Close current tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3781"/>
+        <location filename="../Lektra.cpp" line="4218"/>
         <source>Go to tab by number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3783"/>
+        <location filename="../Lektra.cpp" line="4220"/>
         <source>Switch to tab 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3785"/>
+        <location filename="../Lektra.cpp" line="4222"/>
         <source>Switch to tab 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3787"/>
+        <location filename="../Lektra.cpp" line="4224"/>
         <source>Switch to tab 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3789"/>
+        <location filename="../Lektra.cpp" line="4226"/>
         <source>Switch to tab 4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3791"/>
+        <location filename="../Lektra.cpp" line="4228"/>
         <source>Switch to tab 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3793"/>
+        <location filename="../Lektra.cpp" line="4230"/>
         <source>Switch to tab 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3795"/>
+        <location filename="../Lektra.cpp" line="4232"/>
         <source>Switch to tab 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3797"/>
+        <location filename="../Lektra.cpp" line="4234"/>
         <source>Switch to tab 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3799"/>
+        <location filename="../Lektra.cpp" line="4236"/>
         <source>Switch to tab 9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3803"/>
+        <location filename="../Lektra.cpp" line="4240"/>
         <source>Open document outline picker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3805"/>
+        <location filename="../Lektra.cpp" line="4243"/>
         <source>Search within highlights</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3812"/>
+        <location filename="../Lektra.cpp" line="4247"/>
+        <source>Search annotation comments</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4251"/>
+        <source>Search document</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4253"/>
         <source>Search document using regex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3814"/>
+        <location filename="../Lektra.cpp" line="4257"/>
+        <source>Search from current position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4259"/>
         <source>Jump to next search result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3816"/>
+        <location filename="../Lektra.cpp" line="4261"/>
         <source>Jump to previous search result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3818"/>
+        <location filename="../Lektra.cpp" line="4264"/>
         <source>Search with inline query argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3823"/>
+        <location filename="../Lektra.cpp" line="4267"/>
+        <source>Cancel current search and clear highlights</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4271"/>
         <source>Single page layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3827"/>
+        <location filename="../Lektra.cpp" line="4275"/>
         <source>Horizontal (left to right) layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3830"/>
+        <location filename="../Lektra.cpp" line="4279"/>
         <source>Vertical (top to bottom) layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3833"/>
+        <location filename="../Lektra.cpp" line="4282"/>
         <source>Book (two page spread) layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3838"/>
+        <location filename="../Lektra.cpp" line="4287"/>
+        <source>Show the preview window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4296"/>
+        <source>Open configuration file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4299"/>
         <source>Set device pixel ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3841"/>
+        <location filename="../Lektra.cpp" line="4302"/>
         <source>Open folder containing current file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3843"/>
+        <location filename="../Lektra.cpp" line="4304"/>
         <source>Undo last action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3845"/>
+        <location filename="../Lektra.cpp" line="4306"/>
         <source>Redo last undone action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3848"/>
+        <location filename="../Lektra.cpp" line="4309"/>
         <source>Highlight current text selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3850"/>
+        <location filename="../Lektra.cpp" line="4312"/>
         <source>Toggle inverted colour rendering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3852"/>
+        <location filename="../Lektra.cpp" line="4315"/>
         <source>Re-show the last jump marker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3855"/>
+        <location filename="../Lektra.cpp" line="4318"/>
         <source>Reopen last closed file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3858"/>
+        <location filename="../Lektra.cpp" line="4320"/>
         <source>Copy current page as image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3861"/>
+        <location filename="../Lektra.cpp" line="4323"/>
         <source>Run debug command</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3866"/>
+        <location filename="../Lektra.cpp" line="4328"/>
         <source>Show startup screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3868"/>
+        <location filename="../Lektra.cpp" line="4331"/>
         <source>Open tutorial document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3870"/>
+        <location filename="../Lektra.cpp" line="4333"/>
         <source>Show about dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3885"/>
+        <location filename="../Lektra.cpp" line="4348"/>
         <source>Failed to trim recent files store</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3897"/>
-        <location filename="../Lektra.cpp" line="3902"/>
+        <location filename="../Lektra.cpp" line="4360"/>
+        <location filename="../Lektra.cpp" line="4366"/>
         <source>Set DPR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3897"/>
+        <location filename="../Lektra.cpp" line="4361"/>
         <source>Enter the Device Pixel Ratio (DPR) value: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3966"/>
+        <location filename="../Lektra.cpp" line="4430"/>
         <source>Go to Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3966"/>
+        <location filename="../Lektra.cpp" line="4431"/>
         <source>Enter tab number: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="3973"/>
+        <location filename="../Lektra.cpp" line="4438"/>
         <source>Invalid Tab Number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4283"/>
+        <location filename="../Lektra.cpp" line="4661"/>
+        <source>Search Not Supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4662"/>
+        <source>The current document does not support text search.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4797"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4320"/>
+        <location filename="../Lektra.cpp" line="4834"/>
         <source>Escape key pressed handled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4364"/>
+        <location filename="../Lektra.cpp" line="4881"/>
         <source>Show Tutorial File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4365"/>
-        <source>Not yet implemented for Mac</source>
+        <location filename="../Lektra.cpp" line="4882"/>
+        <source>Tutorial file could not be found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4368"/>
+        <location filename="../Lektra.cpp" line="5799"/>
+        <source>Config file not found at:
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Lektra.cpp" line="4885"/>
         <source>Not yet implemented for Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="4964"/>
+        <location filename="../Lektra.cpp" line="5536"/>
         <source>No recent files found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5022"/>
+        <location filename="../Lektra.cpp" line="5596"/>
         <source>Reopen_last_file: file no longer exists:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5040"/>
-        <location filename="../Lektra.cpp" line="5044"/>
+        <location filename="../Lektra.cpp" line="5619"/>
+        <location filename="../Lektra.cpp" line="5624"/>
         <source>Set Mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5040"/>
+        <location filename="../Lektra.cpp" line="5620"/>
         <source>Enter mark key (a-z for local, A-Z for global):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5044"/>
-        <location filename="../Lektra.cpp" line="5068"/>
-        <location filename="../Lektra.cpp" line="5094"/>
+        <location filename="../Lektra.cpp" line="5625"/>
+        <location filename="../Lektra.cpp" line="5658"/>
+        <location filename="../Lektra.cpp" line="5690"/>
         <source>Mark key cannot be empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5064"/>
-        <location filename="../Lektra.cpp" line="5068"/>
+        <location filename="../Lektra.cpp" line="5652"/>
+        <location filename="../Lektra.cpp" line="5657"/>
         <source>Delete Mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5064"/>
+        <location filename="../Lektra.cpp" line="5653"/>
         <source>Mark to delete:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5090"/>
-        <location filename="../Lektra.cpp" line="5094"/>
+        <location filename="../Lektra.cpp" line="5684"/>
+        <location filename="../Lektra.cpp" line="5689"/>
         <source>Goto Mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Lektra.cpp" line="5090"/>
+        <location filename="../Lektra.cpp" line="5684"/>
         <source>Mark to go to:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1435,13 +1493,13 @@ Loading default config.</source>
 <context>
     <name>OutlinePicker</name>
     <message>
-        <location filename="../OutlinePicker.cpp" line="11"/>
-        <location filename="../OutlinePicker.cpp" line="16"/>
+        <location filename="../OutlinePicker.cpp" line="13"/>
+        <location filename="../OutlinePicker.cpp" line="18"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../OutlinePicker.cpp" line="12"/>
+        <location filename="../OutlinePicker.cpp" line="14"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1449,12 +1507,12 @@ Loading default config.</source>
 <context>
     <name>PopupAnnotation</name>
     <message>
-        <location filename="../Annotations/PopupAnnotation.hpp" line="105"/>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="108"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Annotations/PopupAnnotation.hpp" line="106"/>
+        <location filename="../Annotations/PopupAnnotation.hpp" line="109"/>
         <source>Comment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1475,61 +1533,104 @@ Loading default config.</source>
 <context>
     <name>RectAnnotation</name>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="85"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="86"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="88"/>
         <source>Change Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Annotations/RectAnnotation.hpp" line="87"/>
+        <location filename="../Annotations/RectAnnotation.hpp" line="89"/>
         <source>Comment</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchBar</name>
+    <message>
+        <location filename="../SearchBar.cpp" line="16"/>
+        <source>Search:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="26"/>
+        <source>Regular Expression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="31"/>
+        <source>Goto Next Hit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="32"/>
+        <source>Goto Previous Hit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="33"/>
+        <source>Close Search Bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="55"/>
+        <source>Search query…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="82"/>
+        <source>Invalid Index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SearchBar.cpp" line="83"/>
+        <source>Please enter a valid search index.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Statusbar</name>
     <message>
-        <location filename="../Statusbar.hpp" line="48"/>
-        <source>of</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../Statusbar.cpp" line="120"/>
+        <location filename="../Statusbar.cpp" line="137"/>
         <source>Region Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="127"/>
+        <location filename="../Statusbar.cpp" line="144"/>
         <source>Text Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="134"/>
+        <location filename="../Statusbar.cpp" line="151"/>
         <source>Text Highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="141"/>
+        <location filename="../Statusbar.cpp" line="158"/>
         <source>Annot Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="148"/>
+        <location filename="../Statusbar.cpp" line="165"/>
         <source>Annot Rect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="155"/>
+        <location filename="../Statusbar.cpp" line="172"/>
         <source>Annot Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Statusbar.cpp" line="162"/>
+        <location filename="../Statusbar.cpp" line="179"/>
         <source>Visual Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../Statusbar.hpp" line="48"/>
+        <source>of</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
**Creates translations for newly added strings.**

By the way, thank you for wrapping your newer strings in `tr()` for easier translation! Really much appreciated the work liftoff.

Friendly reminder: your command descriptions should also be wrapped in them to be future-proof: if in the future you want to expose those commands directly to the GUI, they will show up properly translated, hence why I wrapped them in the initial PR. If you do disagree/conclude that they would never be exposed like that, you could just remove the `tr()` from those, but from my perspective, I'd rather be better safe than sorry.

And a question: I know you've changed the code for page enumeration. The "%1 of %2" string is now missing from the code and I can't translate that ""of" anymore to Spanish, so may I ask you: where's the code that currently generates it? When you respond, if this hasn't been merged yet, I'll push another commit and if it is I'll open a new PR:


<img width="523" height="99" alt="Captura de pantalla_20260323_094922" src="https://github.com/user-attachments/assets/6f2e87f3-0f76-4613-a0fb-2dc420733ae0" />



Hope you are doing well, btw!