### PR TITLE
Make custom configuration option not required

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,7 +26,7 @@ body:
       label: Custom configuration used
       options:
         - label: I am using custom configuration.
-          required: true
+          required: false
 
   - type: textarea
     id: custom_config


### PR DESCRIPTION
This seems to be wrongly marked as mandatory, as it's a question and it's optional to have a custom configuration.